### PR TITLE
Correctly propagate statusCode (of API-Gateway Event Response)

### DIFF
--- a/pkg/events/apiGateway/mapper.go
+++ b/pkg/events/apiGateway/mapper.go
@@ -40,7 +40,7 @@ func Request(r *http.Request) {
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(js))
 }
 
-func Response(w http.ResponseWriter, data []byte) (int, error) {
+func Response(w http.ResponseWriter, statusCode int, data []byte) (int, error) {
 	var js events.APIGatewayProxyResponse
 	if err := json.Unmarshal(data, &js); err != nil {
 		return 0, err
@@ -48,6 +48,11 @@ func Response(w http.ResponseWriter, data []byte) (int, error) {
 	for k, v := range js.Headers {
 		w.Header().Set(k, v)
 	}
-	w.WriteHeader(js.StatusCode)
+
+	if js.StatusCode >= 200 {
+		statusCode = js.StatusCode
+	}
+	w.WriteHeader(statusCode)
+
 	return w.Write([]byte(js.Body))
 }


### PR DESCRIPTION
The API-Gateway Event Response has a StatusCode field, and `aws-custom-runtime` already handles that one in the `Response`-mapper.

However this doesn't seem to work correctly, since `newTask` already calls `w.WriteHeader` and sets the response code to 200 (and according to Go documentation only the first `WriteHeader` call wins). This PR overrides `WriteHeader` (like `Write`) and stores the status code to actually apply it if the function itself decided to not set a status code.

PS: bear with me if this isn't (yet) the idiomatic Go solution, it's the first time I've touched Go code :)