### PR TITLE
Handle empty CE Type attribute

### DIFF
--- a/pkg/converter/cloudevents/cloudevents.go
+++ b/pkg/converter/cloudevents/cloudevents.go
@@ -52,6 +52,13 @@ func New() (*CloudEvent, error) {
 }
 
 func (ce *CloudEvent) Convert(data []byte) ([]byte, error) {
+	// If response format is set to CloudEvents
+	// and CE_TYPE is empty,
+	// then reply with the empty response
+	if ce.EventType == "" {
+		return nil, nil
+	}
+
 	b := ceBody{
 		ID:          uuid.NewString(),
 		Type:        ce.EventType,


### PR DESCRIPTION
If the response format set to cloudevents but CE_TYPE is empty, reply with status header and empty body.
As I said in https://github.com/triggermesh/function/pull/15#discussion_r628005512, it is too complicated :smirk: 