### PR TITLE
Request conversion

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -63,7 +63,7 @@ func TestNewTask(t *testing.T) {
 	defer close(tasks)
 
 	recorder := httptest.NewRecorder()
-	h := http.HandlerFunc(handler.newTask)
+	h := http.HandlerFunc(handler.serve)
 
 	req, err := http.NewRequest("POST", "/", bytes.NewBuffer(payload))
 	if err != nil {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -17,12 +17,15 @@ limitations under the License.
 package converter
 
 import (
+	"net/http"
+
 	"github.com/triggermesh/aws-custom-runtime/pkg/converter/cloudevents"
 	"github.com/triggermesh/aws-custom-runtime/pkg/converter/plain"
 )
 
 type Converter interface {
-	Convert([]byte) ([]byte, error)
+	Response([]byte) ([]byte, error)
+	Request([]byte, http.Header) ([]byte, map[string]string, error)
 	ContentType() string
 }
 

--- a/pkg/converter/plain/plain.go
+++ b/pkg/converter/plain/plain.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package plain
 
+import "net/http"
+
 type Plain struct{}
 
 const contentType = "plain/text"
@@ -24,8 +26,12 @@ func New() (*Plain, error) {
 	return &Plain{}, nil
 }
 
-func (p *Plain) Convert(data []byte) ([]byte, error) {
+func (p *Plain) Response(data []byte) ([]byte, error) {
 	return data, nil
+}
+
+func (p *Plain) Request(request []byte, headers http.Header) ([]byte, map[string]string, error) {
+	return request, nil, nil
 }
 
 func (p *Plain) ContentType() string {


### PR DESCRIPTION
- Incoming tasks processing divided into two functions, `server` and `enqueue`, to improve readability,
- New converter method handles the body and the headers of the requests,
- Request headers are passed as the task context and accessible as the read-only variables.

Related to triggermesh/function#13