### PR TITLE
Remove environment overrides that cause problems for the buildpack case.

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func setupEnv(internalAPIport string) error {
 	environment["AWS_LAMBDA_RUNTIME_API"] += ":" + internalAPIport
 
 	for k, v := range environment {
-		if err := os.Setenv(k, v); err != nil {
+		if err := os.Setenv(k, os.ExpandEnv(v)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Buildpacks tend to create layers like `/layers/$layer_name/...` and then set environment variables like `$PATH` to fix up execution. Overriding `$PATH` and `$LD_LIBRARY_PATH` in the runtime caused errors when I was trying to make / package https://github.com/evankanderson/klr-buildpack.﻿
