### PR TITLE
Migrate to Zap logger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     executor:
       name: go/default
-      tag: '1.15'
+      tag: '1.18'
     working_directory: ~/go/src/github.com/triggermesh/aws-custom-runtime
     steps:
       - checkout
@@ -18,7 +18,7 @@ jobs:
   test:
     executor:
       name: go/default
-      tag: '1.15'
+      tag: '1.18'
     working_directory: ~/go/src/github.com/triggermesh/aws-custom-runtime
     steps:
       - checkout
@@ -45,7 +45,7 @@ jobs:
   release:
     executor:
       name: go/default
-      tag: '1.15'
+      tag: '1.18'
     working_directory: ~/go/src/github.com/triggermesh/aws-custom-runtime
     steps:
       - checkout

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ go 1.15
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.1
+	github.com/blendle/zapdriver v1.3.1
 	github.com/cloudevents/sdk-go/v2 v2.8.0
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	go.opencensus.io v0.23.0
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
+	go.uber.org/zap v1.19.1
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
 	golang.org/x/tools v0.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
+github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 Triggermesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/blendle/zapdriver"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	// Environment variable used by Knative to pass Zap logging config.
+	EnvLoggingConfigJson = "K_LOGGING_CONFIG"
+	// JSON's key that stores Zap configuration.
+	ZapLoggerConfigKey = "zap-logger-config"
+)
+
+// JSON structure to access Zap configuration.
+type loggingEnvConfig struct {
+	ZapConfig string `json:"zap-logger-config,omitempty"`
+}
+
+// New returns sugared Zap logger.
+func New() *zap.SugaredLogger {
+	zapConfig := defaultProductionConfig()
+	var err error
+
+	configJSON, exists := os.LookupEnv(EnvLoggingConfigJson)
+	if exists && configJSON != "" {
+		if err = updateConfigFromJSON(&zapConfig, configJSON); err != nil {
+			panic(err)
+		}
+	}
+
+	logger, err := zapConfig.Build()
+	if err != nil {
+		panic(err)
+	}
+
+	return logger.Sugar()
+}
+
+// updateConfigFromJSON updates default Zap configuration with configuration passed
+// in environment variable.
+func updateConfigFromJSON(defaultConfig *zap.Config, configJSON string) error {
+	var lc loggingEnvConfig
+	if err := json.Unmarshal([]byte(configJSON), &lc); err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(lc.ZapConfig), defaultConfig)
+}
+
+// defaultProductionConfig creates default production logger config.
+func defaultProductionConfig() zap.Config {
+	cfg := zapdriver.NewProductionConfig()
+	cfg.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
+	return cfg
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,7 +19,6 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -156,7 +155,7 @@ func (r *EventProcessingStatsReporter) ReportProcessingLatency(d time.Duration, 
 func StatsExporter() (*EventProcessingStatsReporter, error) {
 	var env env
 	if err := envconfig.Process("", &env); err != nil {
-		log.Fatalf("Cannot process metrics env variables: %v", err)
+		return nil, fmt.Errorf("cannot process metrics env variables: %w", err)
 	}
 
 	registerEventProcessingStatsView()
@@ -180,7 +179,7 @@ func StatsExporter() (*EventProcessingStatsReporter, error) {
 		metricsExporter := http.NewServeMux()
 		metricsExporter.Handle("/metrics", pe)
 		if err := http.ListenAndServe(":"+env.PrometheusPort, metricsExporter); err != nil {
-			log.Fatalf("Failed to run Prometheus scrape endpoint: %v", err)
+			panic(err)
 		}
 	}()
 


### PR DESCRIPTION
- Switch from standard `log` to `Zap.Logger`,
- If set, use `K_LOGGING_CONFIG` env variable to match TriggerMesh core logging format,

- A couple of "cosmetic" updates such as `deadline` and `ttl` types changed to time.Time and time.Duration,
- timestamp as a task id replaced with uuid.

Resolves #43