### PR TITLE
ci: setup go 1.19 for goreleaser

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -54,6 +54,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.19'
+
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v4
       with:


### PR DESCRIPTION
@tzununbekov this should fix the goreleaser release after the mod update