### PR TITLE
feat: align expected lambda headers

### DIFF
--- a/pkg/converter/cloudevents/cloudevents.go
+++ b/pkg/converter/cloudevents/cloudevents.go
@@ -31,8 +31,9 @@ import (
 
 // CloudEvents request constant attributes.
 const (
-	ContentType = "application/cloudevents+json"
-	ContextKey  = "Lambda-Runtime-Cloudevents-Context"
+	ContentType      = "application/cloudevents+json"
+	CeContextKey     = "Lambda-Runtime-Cloudevents-Context"
+	ClientContextKey = "Lambda-Runtime-Client-Context"
 )
 
 // CloudEvent is a data structure required to map KLR responses to cloudevents
@@ -142,11 +143,12 @@ func (ce *CloudEvent) Request(request []byte, headers http.Header) ([]byte, map[
 
 	ceContext, err := json.Marshal(context)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot encode request context: %w", err)
+		return nil, nil, fmt.Errorf("cannot encode request event context: %w", err)
 	}
 
 	runtimeContext := map[string]string{
-		ContextKey: string(ceContext),
+		ClientContextKey: fmt.Sprintf("{\"custom\":%s}", ceContext),
+		CeContextKey:     string(ceContext),
 	}
 
 	return body, runtimeContext, nil

--- a/pkg/converter/cloudevents/cloudevents_test.go
+++ b/pkg/converter/cloudevents/cloudevents_test.go
@@ -1,0 +1,73 @@
+package cloudevents
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCloudEvent_Request(t *testing.T) {
+	tests := []struct {
+		name                   string
+		request                string
+		headers                http.Header
+		expectedBody           string
+		expectedRuntimeContext map[string]string
+		wantErr                bool
+	}{
+		{
+			name:    "Event of type application/cloudevents+json",
+			request: `{"source":"test","data":{"foo":"bar"}}`,
+			headers: http.Header{
+				"Content-Type": {"application/cloudevents+json"},
+			},
+			expectedBody: `{"foo":"bar"}`,
+			expectedRuntimeContext: map[string]string{
+				CeContextKey:     `{"source":"test"}`,
+				ClientContextKey: `{"custom":{"source":"test"}}`,
+			},
+		},
+		{
+			name:    "Event of type application/json",
+			request: `{"foo":"bar"}`,
+			headers: http.Header{
+				"Content-Type": {"application/json"},
+				"ce-source":    {"test"},
+			},
+			expectedBody: `{"foo":"bar"}`,
+			expectedRuntimeContext: map[string]string{
+				CeContextKey:     `{"source":"test"}`,
+				ClientContextKey: `{"custom":{"source":"test"}}`,
+			},
+		},
+		{
+			name:    "Event of other type",
+			request: `hello world`,
+			headers: http.Header{
+				"Content-Type": {"text/plain"},
+			},
+			expectedBody:           `hello world`,
+			expectedRuntimeContext: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ce := &CloudEvent{}
+			body, runtimeContext, err := ce.Request([]byte(tt.request), tt.headers)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Request() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(string(body), tt.expectedBody) {
+				t.Errorf("Request() got = %v, want %v", string(body), tt.expectedBody)
+			}
+
+			if !reflect.DeepEqual(runtimeContext, tt.expectedRuntimeContext) {
+				t.Errorf("Request() got1 = %v, want %v", runtimeContext, tt.expectedRuntimeContext)
+			}
+		})
+	}
+}

--- a/pkg/metrics/cloudevents.go
+++ b/pkg/metrics/cloudevents.go
@@ -40,7 +40,7 @@ func CETagsFromContext(context map[string]string) (tag.Mutator, tag.Mutator) {
 	if context == nil {
 		return DefaultRequestType, DefaultRequestSource
 	}
-	ceContext, exists := context[cloudevents.ContextKey]
+	ceContext, exists := context[cloudevents.CeContextKey]
 	if !exists {
 		return DefaultRequestType, DefaultRequestSource
 	}


### PR DESCRIPTION
Following latest updates of the AWS Lambda Runtime interfaces, passed headers to the handler are now filtered. `Lambda-Runtime-Cloudevents-Context` is kept for retrocompatibility.

To access the CloudEvent context:

Python

```python
def handler(event, context):
  print(context.client_context.custom)
```

NodeJS/Typsecript

```typescript
exports.handler = async function(event, context) {
  console.log(context.clientContext.Custom)
}
```

Do note that depending on the runtime, you might need to unserialize the custom context first.

See:
https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-next